### PR TITLE
remove ion-functions submodule in favor of manual install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ion-functions"]
-	path = ion-functions
-	url = https://github.com/ooici/ion-functions

--- a/config.py
+++ b/config.py
@@ -16,4 +16,4 @@ CASSANDRA_FETCH_SIZE = 1000
 SPREADSHEET_KEY = '1jIiBKpVRBMU5Hb1DJqyR16XCkiX-CuTsn1Z1VnlRV4I'
 USE_CACHED_SPREADSHEET = False
 
-sys.path.append('ion-functions')
+#sys.path.append('ion-functions')

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -18,7 +18,7 @@ from util.preload_insert import create_db
 from util.calc import StreamRequest, find_stream, stretch, interpolate, handle_byte_buffer, execute_dpa, build_func_map
 
 
-sys.path.append('../ion-functions')
+#sys.path.append('../ion-functions')
 
 TEST_DIR = os.path.dirname(__file__)
 


### PR DESCRIPTION
I have installed ion-functions into the pre-packaged python and it seems to work correctly.  I updated the wiki page with the new instructions.